### PR TITLE
Adding back the config-bootstrapper dependency.

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -20,3 +20,8 @@ type: application
 # to the chart and its templates, including the app version. The "helm package" command will take care of setting this.
 # A new chart will be created for each new version of the service.
 version: 0.1.0
+
+dependencies:
+  - name: config-bootstrapper
+    repository: "https://storage.googleapis.com/hypertrace-helm-charts"
+    version: 0.1.0


### PR DESCRIPTION
With this, the helm chart will bring back the functionality to initialize the Attributes after the service comes up, by using post-install helm hook.