### PR TITLE
adding metrics reporter prefix for the service

### DIFF
--- a/attribute-service/src/main/resources/configs/common/application.conf
+++ b/attribute-service/src/main/resources/configs/common/application.conf
@@ -10,3 +10,9 @@ document.store {
   }
 }
 attributes.type.server.port = 9012
+
+metrics.reporter {
+  prefix = org.hypertrace.core.attribute.service.AttributeService
+  names = ["prometheus"]
+  console.reportInterval = 30
+}


### PR DESCRIPTION
- to differentiate it from a pool of services for common JVM metrics