### PR TITLE
provides a way to override the mongo_host via an environment variable

### DIFF
--- a/attribute-service/src/integrationTest/resources/configs/attribute-service/application.conf
+++ b/attribute-service/src/integrationTest/resources/configs/attribute-service/application.conf
@@ -5,7 +5,7 @@ document.store {
   dataStoreType = mongo
   mongo {
     host = localhost
-    host = ${?mongo_host} # provides a way to override the mongo_host via an environment variable
+    host = ${?MONGO_HOST} # provides a way to override the mongo_host via an environment variable
     port = 27017
   }
 }

--- a/attribute-service/src/main/resources/configs/common/application.conf
+++ b/attribute-service/src/main/resources/configs/common/application.conf
@@ -5,7 +5,7 @@ document.store {
   dataStoreType = mongo
   mongo {
     host = localhost
-    host = ${?mongo_host} # provides a way to override the mongo_host via an environment variable
+    host = ${?MONGO_HOST} # provides a way to override the mongo_host via an environment variable
     port = 27017
   }
 }


### PR DESCRIPTION
- convert an exposed mongo_host property to upper case to be consistent with other environ properties