### PR TITLE
adds illustrations to help understand attribute service and building steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,39 @@
 # Attribute service
 
-Service to provide CRUD operations for the attributes in Hypertrace.
+Attribute service provides CRUD operations for the attributes in Hypertrace.
+
+It fetches all attributes relevant to the scope of what is being shown on UI. The concept of Attributes helps build a generic framework of communication between the UI and backend.
 
 ## What are Attributes?
-An attribute represents a piece of data that's present in Hypertrace
-that's available for querying. Attribute metadata gives the type of the
-data, kind of aggregations allowed on it, services which serve that attribute, etc.
-See `attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto`
-for the structure of an attribute.
+An attribute represents a piece of data that's present in Hypertrace that's available for querying. It is a highly generic building block of what queries/show/display/represent in the UI. Attribute metadata gives the type of the data, kind of aggregations allowed on it, services which serve that attribute, etc.
+
+Ex.
+```
+key: apiName,
+value_kind: TYPE_STRING,
+groupable : true,
+display_name: Endpoint Name,
+scope: API_TRACE,
+sources: [QS],
+type: ATTRIBUTE
+```
+
+You can check out structure of attribute [here](https://github.com/hypertrace/attribute-service/blob/main/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto).
 
 ### How are attributes created?
-An initial list of attributes needed by Hypertrace are seeded from `helm/configs` but they
-can also be dynamically registered and queried using the APIs of AttributeService.
+An initial list of attributes needed by Hypertrace are seeded from helm/configs but they can also be dynamically registered and queried using the APIs of AttributeService.
+
+## How do we use Attribute service
+
+Attribute service is a part of query architecture in Hypertrace and here is the use of it in context of its callers: [hypertrace-graphql](https://github.com/hypertrace/hypertrace-graphql) and [gateway-service](https://github.com/hypertrace/gateway-service). 
+
+| ![space-1.jpg](https://hypertrace-docs.s3.amazonaws.com/hypertrace-query-arch.png) | 
+|:--:| 
+| *Hypertrace Query Architecture* |
+
+Attribute service fetches all attributes relevant to the scope of what is being shown on UI from Mongo and where it also stores attributes. All of this metadata assists the UI and backend to perform things in a generic fashion, like
+- All String attributes in the UI can have a different look at feel and also different operations that can be supported on them(in the explorer).
+- The backend also uses part of the information(like the sources) to figure out where to fetch data from i.e. query-service vs entity-service.
 
 ## Building locally
 The Attribute service uses gradlew to compile/install/distribute. Gradle wrapper is already part of the source code. To build Attribute Service, run:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Attribute service
+# Attribute Service
 
 Attribute service provides CRUD operations for the attributes in Hypertrace.
 
@@ -29,7 +29,7 @@ An initial list of attributes needed by Hypertrace are seeded from `helm/configs
 
 Attribute service is a part of query architecture in Hypertrace and here is the use of it in context of its callers: [hypertrace-graphql](https://github.com/hypertrace/hypertrace-graphql) and [gateway-service](https://github.com/hypertrace/gateway-service). 
 
-| ![space-1.jpg](https://hypertrace-docs.s3.amazonaws.com/HT-query-architecture.png) | 
+| ![space-1.jpg](https://hypertrace-docs.s3.amazonaws.com/HT-query-arch.png) | 
 |:--:| 
 | *Hypertrace Query Architecture* |
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Attribute service provides CRUD operations for the attributes in Hypertrace.
 
-It fetches all attributes relevant to the scope of what is being shown on UI. The concept of Attributes helps build a generic framework of communication between the UI and backend.
-
 ## What are Attributes?
 An attribute is a granular piece of information that is present in Hypertrace and available for querying/displaying in the UI. An attribute encapsulates information like 1) the type of the data, 2) kind of aggregations allowed on it, 3) underlying service/source that can serve this data etc.
 This helps in building a generic framework of communication between the UI and the backend and also assists the backend to fetch data from the appropriate sources in a generic way.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ scope: API_TRACE,
 sources: [QS],
 type: ATTRIBUTE
 ```
+While hypertrace offers a simple service model, it also permits storing certain fields in different backends. Attributes include tags to help locate the service hosting their corresponding data.
+
+For example, `apiName` is generated from raw trace data streams. `sources: [QS]`  communicates this, as **Q**uery **S**ervice is the api that queries that data (via Pinot).
 
 You can check out structure of attribute [here](https://github.com/hypertrace/attribute-service/blob/main/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Attribute-service
+# Attribute service
 
 Service to provide CRUD operations for the attributes in Hypertrace.
 
@@ -12,20 +12,6 @@ for the structure of an attribute.
 ### How are attributes created?
 An initial list of attributes needed by Hypertrace are seeded from `helm/configs` but they
 can also be dynamically registered and queried using the APIs of AttributeService.
-
-## How Hypertrace uses Attribute service?
-Below is the high level schematic diagram(of the push based model) of different components involved in attribute service:
-
-| ![space-1.jpg](https://imagizer.imageshack.com/v2/xq90/924/xN2Top.png) | 
-|:--:| 
-| *Attribute service schematic representation* |
-
-
-
-| ![space-1.jpg](https://imagizer.imageshack.com/v2/xq90/924/ankE6z.png) | 
-|:--:| 
-| *All flows involving Attribute service* |
-
 
 ## Building locally
 The Attribute service uses gradlew to compile/install/distribute. Gradle wrapper is already part of the source code. To build Attribute Service, run:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# attribute-service
+# Attribute-service
 
 Service to provide CRUD operations for the attributes in Hypertrace.
 
-### What are Attributes?
+## What are Attributes?
 An attribute represents a piece of data that's present in Hypertrace
 that's available for querying. Attribute metadata gives the type of the
 data, kind of aggregations allowed on it, services which serve that attribute, etc.
@@ -12,3 +12,31 @@ for the structure of an attribute.
 ### How are attributes created?
 An initial list of attributes needed by Hypertrace are seeded from `helm/configs` but they
 can also be dynamically registered and queried using the APIs of AttributeService.
+
+## How Hypertrace uses Attribute service?
+Below is the high level schematic diagram(of the push based model) of different components involved in attribute service:
+
+| ![space-1.jpg](https://imagizer.imageshack.com/v2/xq90/924/xN2Top.png) | 
+|:--:| 
+| *Attribute service schematic representation* |
+
+
+
+| ![space-1.jpg](https://imagizer.imageshack.com/v2/xq90/924/ankE6z.png) | 
+|:--:| 
+| *All flows involving Attribute service* |
+
+
+## Building locally
+The Attribute service uses gradlew to compile/install/distribute. Gradle wrapper is already part of the source code. To build Attribute Service, run:
+
+```
+./gradlew clean build dockerBuildImages
+```
+
+## Docker Image Source:
+- [DockerHub > Attribute service](https://hub.docker.com/r/hypertrace/attribute-service)
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ type: ATTRIBUTE
 You can check out structure of attribute [here](https://github.com/hypertrace/attribute-service/blob/main/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto).
 
 ### How are attributes created?
-An initial list of attributes needed by Hypertrace are seeded from helm/configs but they can also be dynamically registered and queried using the APIs of AttributeService.
+An initial list of attributes needed by Hypertrace are seeded from `helm/configs` but they can also be dynamically registered and queried using the APIs of AttributeService.
 
 ## How do we use Attribute service
 
 Attribute service is a part of query architecture in Hypertrace and here is the use of it in context of its callers: [hypertrace-graphql](https://github.com/hypertrace/hypertrace-graphql) and [gateway-service](https://github.com/hypertrace/gateway-service). 
 
-| ![space-1.jpg](https://hypertrace-docs.s3.amazonaws.com/hypertrace-query-arch.png) | 
+| ![space-1.jpg](https://hypertrace-docs.s3.amazonaws.com/HT-query-architecture.png) | 
 |:--:| 
 | *Hypertrace Query Architecture* |
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ Attribute service provides CRUD operations for the attributes in Hypertrace.
 It fetches all attributes relevant to the scope of what is being shown on UI. The concept of Attributes helps build a generic framework of communication between the UI and backend.
 
 ## What are Attributes?
-An attribute represents a piece of data that's present in Hypertrace that's available for querying. It is a highly generic building block of what queries/show/display/represent in the UI. Attribute metadata gives the type of the data, kind of aggregations allowed on it, services which serve that attribute, etc.
+An attribute is a granular piece of information that is present in Hypertrace and available for querying/displaying in the UI. An attribute encapsulates information like 1) the type of the data, 2) kind of aggregations allowed on it, 3) underlying service/source that can serve this data etc.
+This helps in building a generic framework of communication between the UI and the backend and also assists the backend to fetch data from the appropriate sources in a generic way.
 
 Ex.
 ```
@@ -44,7 +45,6 @@ The Attribute service uses gradlew to compile/install/distribute. Gradle wrapper
 
 ## Docker Image Source:
 - [DockerHub > Attribute service](https://hub.docker.com/r/hypertrace/attribute-service)
-
 
 
 

--- a/attribute-service-client/build.gradle.kts
+++ b/attribute-service-client/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
   api(project(":attribute-service-api"))
   api("com.typesafe:config:1.3.2")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.1.3")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.2.0")
 }

--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
   }
 
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.1.3")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")
   implementation("com.typesafe:config:1.3.2")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   implementation(project(":attribute-service-impl"))
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.3")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.1.3")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.2.0")
   implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
 
   // Logging


### PR DESCRIPTION
This PR
- Answers how Hypertrace uses attribute service
- Adds schematic representation for attribute service 
- Adds flows involving attribute service
- Add steps to build image locally
- link to dockerhub image source