### PR TITLE
feat: Upgrading docstore version to upgrade mongo java driver.

### DIFF
--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   api(project(":attribute-service-api"))
   implementation(project(":attribute-service-tenant-api"))
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.16")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.2.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.1.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.4.2")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.25")


### PR DESCRIPTION
## Description
Upgrading the docstore version to latest, which changes the mongo java driver used from 3.12 to 4.1.1. This is because the previous java driver is very old, marked legacy driver by MongoDB and there are a lot of bug fixes in the newer versions.

Most importantly, we are running into some issues with bulk upsert in production and we're trying to see if we see those same issues with the latest Mongo java driver too.

### Testing
Ran Hypertrace locally with the locally built image and things are working fine.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
No functionality is changed, hence no docs needed.
