### PR TITLE
fix: switched return type and first argument type in projection registry

### DIFF
--- a/attribute-projection-registry/src/main/java/org/hypertrace/core/attribute/service/projection/AttributeProjectionRegistry.java
+++ b/attribute-projection-registry/src/main/java/org/hypertrace/core/attribute/service/projection/AttributeProjectionRegistry.java
@@ -29,14 +29,14 @@ public class AttributeProjectionRegistry {
               AttributeKind.TYPE_STRING, AttributeKind.TYPE_STRING, Hash::hash),
           PROJECTION_OPERATOR_STRING_EQUALS,
           new BinaryAttributeProjection<>(
-              AttributeKind.TYPE_STRING,
-              AttributeKind.TYPE_STRING,
               AttributeKind.TYPE_BOOL,
+              AttributeKind.TYPE_STRING,
+              AttributeKind.TYPE_STRING,
               Equals::stringEquals),
           PROJECTION_OPERATOR_CONDITIONAL,
           new TernaryAttributeProjection<>(
-              AttributeKind.TYPE_BOOL,
               AttributeKind.TYPE_STRING,
+              AttributeKind.TYPE_BOOL,
               AttributeKind.TYPE_STRING,
               AttributeKind.TYPE_STRING,
               Conditional::getValue


### PR DESCRIPTION
The return type and first argument type were switched for CONDITIONAL and STRING_EQUALS. The return type is the first argument in the projection.
