### PR TITLE
adding qoute for supporting colon in url

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
       {{ $dst }} {
         {{- range $key, $value := (index .Values "configMap" (printf "%s" $dst)) }}
         {{- if $value }}
-        {{ $key }} = {{ $value }}
+        {{ $key }} = {{ $value | quote }}
         {{- end }}
         {{- end }}
       }


### PR DESCRIPTION
## Description
fix the qoute issue to supports url with a colon for document store configuration 
e.g "mongodb://mongo:27017"

HOCON treats `:` as a value separator (https://github.com/lightbend/config/blob/master/HOCON.md#key-value-separator), fixing the parsing error by quoting each value string.


### Testing
Tried locally with - `helm template ./helm/` by adding above `url` values in values.yaml file.
e.g output:
```
application.conf: |-
    document.store {
      dataStoreType = mongo
      mongo {
        host = "mongo"
        url = "mongodb://mongo:27017"
      }
    }
```
### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
Not required