### PR TITLE
allows tagOverride for helm charts

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "service.image" -}}
+  {{- if and .Values.image.tagOverride  -}}
+    {{- printf "%s:%s" .Values.image.repository .Values.image.tagOverride }}
+  {{- else -}}
+    {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
+  {{- end -}}
+{{- end -}}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,7 +1,7 @@
-{{- define "service.image" -}}
+{{- define "attributeservice.image" -}}
   {{- if and .Values.image.tagOverride  -}}
     {{- printf "%s:%s" .Values.image.repository .Values.image.tagOverride }}
   {{- else -}}
-    {{- printf "%s:%s" .Values.image.repository .Chart.Version }}
+    {{- printf "%s:%s" .Values.image.repository .Chart.AppVersion }}
   {{- end -}}
 {{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ include "service.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: grpc-port

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ include "service.image" . }}"
+          image: "{{ include "attributeservice.image" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: grpc-port

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -7,6 +7,7 @@ maxUnavailable: 0
 image:
   repository: hypertrace/attribute-service
   pullPolicy: IfNotPresent
+  tagOverride: ""
 
 imagePullSecrets: {}
 


### PR DESCRIPTION
## Description
addresses https://github.com/hypertrace/hypertrace/issues/55
based on: https://github.com/hypertrace/pinot/pull/18

### Testing
Tested with personal EKS cluster deployment by adding following lines in values.yaml for hypertrace deployment.


```
attribute-service:
  image:
    repository: "hypertrace/attribute-service"
    tagOverride: "main"
```
<img width="844" alt="Screenshot 2020-11-26 at 5 59 15 PM" src="https://user-images.githubusercontent.com/26570044/100351220-1c29a280-3011-11eb-870e-1d3a3f1cdcd8.png">

Works as expected. 

### Checklist:
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
