### PR TITLE
Update README for running integration test locally

### DIFF
--- a/attribute-service/src/integrationTest/README.md
+++ b/attribute-service/src/integrationTest/README.md
@@ -1,9 +1,7 @@
 <h4>How do I run the integration tests locally?</h4>
 
-- Bring up a mongodb container locally using Docker or port forward to the mongo container in Kubernetes
+Run via CLI:
+    `./gradlew integrationTest`
+  or
 
-    `docker run --name mongo-local -p 27017:27017 -d mongo`
-    or
-    `kubectl port-forward mongo-0 27017:27017 -n hypertrace-core`
-      
-- Run the integration tests from IDE
+Run the integration tests from IDE


### PR DESCRIPTION
The current README for running the integration test locally mentions that before running the integration test, `Bring up a mongodb container locally using Docker or port forward to the mongo container in Kubernetes`. This step is actually not required. In fact, port forwarding while running the integration test may lead to modification of the shared database.

So, we need to update the README with the correct instructions.