### PR TITLE
avoids exposing env variables in pr-build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,6 @@
 
 # global
 * @buchi-busireddy @avinashkolluru @tim-mwangi
+
+# GH action
+.github/* @aaron-steinfeld @jbahire @kotharironak @buchi-busireddy

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -7,7 +7,6 @@ on:
     branches: 
       - main
 
-
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -39,9 +39,6 @@ jobs:
       
       - name: Build with Gradle
         run: ./gradlew build dockerBuildImages
-        env:
-          DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
   validate-helm-charts:
     runs-on: ubuntu-20.04

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request_target:
+    branches: 
+      - main
 
 
 jobs:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -5,7 +5,6 @@ on:
       - main
   pull_request:
 
-
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,7 @@ jobs:
           DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
 
   publish-helm-charts:
+    needs: publish-images
     runs-on: ubuntu-20.04
     container: 
       image: hypertrace/helm-gcs-packager:0.3.0


### PR DESCRIPTION
## Description
- Avoids exposing secrets in `pr-build` which runs in `pull_request_target` context. 
- adds publish-images dependency for helm chart publish job. 
- Adds codeowners for github actions


### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

