### PR TITLE
updates required job name for helm publish in GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
           ORG_GRADLE_PROJECT_publishApiKey: ${{ secrets.BINTRAY_API_KEY }}
 
   publish-helm-charts:
-    needs: publish-images
+    needs: publish-artifacts
     runs-on: ubuntu-20.04
     container: 
       image: hypertrace/helm-gcs-packager:0.3.1


### PR DESCRIPTION
## Description
updates required job name to `publish-artifacts` as it was changed earlier. 