### PR TITLE
switches to GITHUB_REF for tagging helm charts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
           HELM_GCS_CREDENTIALS: ${{ secrets.HELM_GCS_CREDENTIALS }}
           HELM_GCS_REPOSITORY: ${{ secrets.HELM_GCS_REPOSITORY }}
         run: |
-            CHART_VERSION=$(git describe --abbrev=0)
+            CHART_VERSION=$(echo ${GITHUB_REF} | cut -d/ -f 3)
             CHART_NAME=$(awk '/^name:/ {print $2}' ./helm/Chart.yaml)
             export GOOGLE_APPLICATION_CREDENTIALS=${HOME}/helm-gcs-key.json
             echo $HELM_GCS_CREDENTIALS > ${GOOGLE_APPLICATION_CREDENTIALS}


### PR DESCRIPTION
## Description
We are using `git describe --abbrev=0` for tagging charts but it's somehow is still on `0.8.7` and we are not able to release helm charts because of that. 

With this PR, we are using GITHUB_REF to get tag for helm charts as well which is standard practice. 