### PR TITLE
chore: bump doc-store version to include SQLi fix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,5 +5,5 @@ ignore:
   SNYK-JAVA-IONETTY-1042268:
     - '*':
         reason: No replacement available
-        expires: 2021-01-31T00:00:00.000Z
+        expires: 2021-02-28T00:00:00.000Z
 patch: {}

--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   api(project(":attribute-service-api"))
   implementation(project(":attribute-service-tenant-api"))
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.5")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.19")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.2.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.4.4")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.25")


### PR DESCRIPTION
Updates doc-store version to include SQLi fix - hypertrace/document-store#30

