### PR TITLE
chore: bump doc-store version to include postgres impl of exits, not-exits and neq

### DIFF
--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -8,7 +8,7 @@ dependencies {
   api(project(":attribute-service-api"))
   implementation(project(":attribute-service-tenant-api"))
 
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.2.0")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.9.5")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
 
   runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")
   runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
-  
+
   // Config
   implementation("com.typesafe:config:1.3.2")
 

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -58,7 +58,7 @@ dependencies {
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.19")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.2.0")
-  implementation("org.hypertrace.core.documentstore:document-store:0.5.1")
+  implementation("org.hypertrace.core.documentstore:document-store:0.5.3")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.25")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -66,15 +66,10 @@ dependencies {
 
   // GRPC
   runtimeOnly("io.grpc:grpc-netty:1.33.0")
-  constraints {
-    runtimeOnly("io.netty:netty-codec-http2:4.1.54.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439")
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.54.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1020439s")
-    }
-  }
 
+  runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")
+  runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
+  
   // Config
   implementation("com.typesafe:config:1.3.2")
 

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -66,9 +66,14 @@ dependencies {
 
   // GRPC
   runtimeOnly("io.grpc:grpc-netty:1.33.0")
-
-  runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final")
-  runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final")
+  constraints {
+    runtimeOnly("io.netty:netty-codec-http2:4.1.59.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1070799")
+    }
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.59.Final") {
+      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1070799")
+    }
+  }
 
   // Config
   implementation("com.typesafe:config:1.3.2")


### PR DESCRIPTION
Updates doc-store version to include postgres impl of exists, not-exists, and NEQ filters 
- https://github.com/hypertrace/document-store/pull/35
- https://github.com/hypertrace/document-store/pull/33