### PR TITLE
feat: add way of defining an attribute from first class field

### DIFF
--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
@@ -144,6 +144,13 @@ message AttributeDefinition {
   oneof value {
     Projection projection = 1;
     string source_path = 2;
+    SourceField source_field = 3;
+  }
+
+  enum SourceField {
+    SOURCE_FIELD_UNSET = 0;
+    SOURCE_FIELD_START_TIME = 1;
+    SOURCE_FIELD_END_TIME = 2;
   }
 }
 


### PR DESCRIPTION
## Description
We previously allowed defining an attribute based on its string key, but certain fields in a span and trace are treated as first class and only accessible through those concrete fields. This change adds support to the attribute definition schema to access those values.

### Testing
Schema change only (but used this functionality as part of an e2e verification)

### Checklist:
- [x] My changes generate no new warnings
- [N/A] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

