### PR TITLE
feat: add attribute definition for fallback support

### DIFF
--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
@@ -81,7 +81,7 @@ message AttributeMetadata {
   // can't be the same for different attribute within the same scope
   string key = 3;
   string display_name = 4;
-  AttributeScope scope = 5 [deprecated=true]; // Use scope_string instead
+  AttributeScope scope = 5 [deprecated = true]; // Use scope_string instead
   bool materialized = 6;
   // 1) Attributes can have units (cores / seconds) for presentation
   // 2) Metrics are temporarily combined, and need it for presentation
@@ -132,7 +132,7 @@ message AttributeSourceMetadataDeleteRequest {
 // in the future, we would need to support partial matching for auto-complete
 message AttributeMetadataFilter {
   repeated string fqn = 1;
-  repeated AttributeScope scope = 2 [deprecated=true]; // Use scope_string instead
+  repeated AttributeScope scope = 2 [deprecated = true]; // Use scope_string instead
   repeated string key = 4;
   repeated string scope_string = 5;
 }
@@ -145,12 +145,17 @@ message AttributeDefinition {
     Projection projection = 1;
     string source_path = 2;
     SourceField source_field = 3;
+    AttributeDefinitions first_value_present = 4;
   }
 
   enum SourceField {
     SOURCE_FIELD_UNSET = 0;
     SOURCE_FIELD_START_TIME = 1;
     SOURCE_FIELD_END_TIME = 2;
+  }
+
+  message AttributeDefinitions {
+    repeated AttributeDefinition definitions = 1;
   }
 }
 

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -56,7 +56,7 @@ tasks.integrationTest {
 dependencies {
   implementation(project(":attribute-service-impl"))
 
-  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.22")
+  implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.23")
   implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.4.0")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
 
@@ -82,7 +82,7 @@ dependencies {
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   integrationTestImplementation("com.google.guava:guava:30.1.1-jre")
   integrationTestImplementation(project(":attribute-service-client"))
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.22")
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.23")
 }
 
 application {


### PR DESCRIPTION
## Description
This allows fallback support, where we can propose alternative definitions of an attribute that will be tried in order. For example, if we wanted to get the version of the tracer we could define an attribute with a definition like below, first trying the hypertrace version attribute, and if missing using the otel spec defined one. Changes to support evaluating this will be added to the attribute reader.

```
definition: {
  first_value_present: {
    definitions: [
      {
        source_path: hypertrace.module.version
      },
      {
        source_path: telemetry.sdk.version
      }
    ]
  }
}
```


### Testing
API addition only, but verified it functionally in an e2e setup.
