### PR TITLE
chore: update config bootstrapper with new attr client

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.1.0
 dependencies:
   - name: config-bootstrapper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.2.12
+    version: 0.2.13


### PR DESCRIPTION
## Description
Update to newer config bootstrapper which uses the newer attribute client (and thus supports new attribute definitions as added in `0.11.0`
