### PR TITLE
chore: creating lazy errors

### DIFF
--- a/caching-attribute-service-client/build.gradle.kts
+++ b/caching-attribute-service-client/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
   implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
   implementation("com.google.guava:guava:30.1.1-jre")
+  annotationProcessor("org.projectlombok:lombok:1.18.20")
+  compileOnly("org.projectlombok:lombok:1.18.20")
+  implementation("org.slf4j:slf4j-api:1.7.30")
 
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")


### PR DESCRIPTION
## Description
Excessive error construction was eating up CPU cycles - changed to lazy construction, and added a throttled log message