### PR TITLE
Add Shutdown and grpc health check

### DIFF
--- a/attribute-service-api/build.gradle.kts
+++ b/attribute-service-api/build.gradle.kts
@@ -14,7 +14,7 @@ protobuf {
   }
   plugins {
     id("grpc_java") {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.36.1"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.40.0"
     }
 
     if (generateLocalGoGrpcFiles) {
@@ -52,13 +52,8 @@ sourceSets {
 }
 
 dependencies {
-  api("io.grpc:grpc-stub:1.36.1")
-  api("io.grpc:grpc-protobuf:1.36.1")
-  constraints {
-    implementation("com.google.guava:guava:30.1.1-jre") {
-      because("https://snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-1015415")
-    }
-  }
+  api("io.grpc:grpc-stub:1.40.0")
+  api("io.grpc:grpc-protobuf:1.40.0")
 
   implementation("javax.annotation:javax.annotation-api:1.3.2")
 }

--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_service.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_service.proto
@@ -14,4 +14,13 @@ service AttributeService {
   rpc deleteSourceMetadata (AttributeSourceMetadataDeleteRequest) returns (Empty);
   rpc findAttributes (AttributeMetadataFilter) returns (stream AttributeMetadata);
   rpc findAll (Empty) returns (stream AttributeMetadata);
+  rpc GetAttributes (GetAttributesRequest) returns (GetAttributesResponse);
+}
+
+message GetAttributesRequest {
+  AttributeMetadataFilter filter = 1;
+}
+
+message GetAttributesResponse {
+  repeated AttributeMetadata attributes = 1;
 }

--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_service.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_service.proto
@@ -12,8 +12,12 @@ service AttributeService {
   rpc delete (AttributeMetadataFilter) returns (Empty);
   rpc updateSourceMetadata (AttributeSourceMetadataUpdateRequest) returns (Empty);
   rpc deleteSourceMetadata (AttributeSourceMetadataDeleteRequest) returns (Empty);
-  rpc findAttributes (AttributeMetadataFilter) returns (stream AttributeMetadata);
-  rpc findAll (Empty) returns (stream AttributeMetadata);
+  rpc findAttributes (AttributeMetadataFilter) returns (stream AttributeMetadata) {
+    option deprecated = true;
+  };
+  rpc findAll (Empty) returns (stream AttributeMetadata) {
+    option deprecated = true;
+  };
   rpc GetAttributes (GetAttributesRequest) returns (GetAttributesResponse);
 }
 

--- a/attribute-service-client/build.gradle.kts
+++ b/attribute-service-client/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
   api(project(":attribute-service-api"))
   api("com.typesafe:config:1.4.1")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.0")
 }

--- a/attribute-service-client/build.gradle.kts
+++ b/attribute-service-client/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
   api(project(":attribute-service-api"))
   api("com.typesafe:config:1.4.1")
 
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.5.2")
 }

--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -9,12 +9,13 @@ dependencies {
   implementation(project(":attribute-service-tenant-api"))
 
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.slf4j:slf4j-api:1.7.30")
   implementation("com.google.protobuf:protobuf-java-util:3.15.6")
+  implementation("com.google.guava:guava:30.1.1-jre")
 
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")

--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
   implementation(project(":attribute-service-tenant-api"))
 
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.0")
 
   implementation("com.fasterxml.jackson.core:jackson-databind:2.12.2")
   implementation("com.typesafe:config:1.4.1")

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/AttributeServiceImplTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/AttributeServiceImplTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Iterators;
 import com.google.protobuf.ServiceException;
 import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
@@ -32,6 +33,45 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 public class AttributeServiceImplTest {
+
+  private static final AttributeMetadata MOCK_EVENT_NAME_ATTRIBUTE =
+      AttributeMetadata.newBuilder()
+          .setFqn("EVENT.name")
+          .setId("EVENT.name")
+          .setKey("name")
+          .setScope(AttributeScope.EVENT)
+          .setScopeString(AttributeScope.EVENT.name())
+          .setDisplayName("EVENT name")
+          .setValueKind(AttributeKind.TYPE_STRING)
+          .setDefinition(AttributeDefinition.getDefaultInstance())
+          .setGroupable(true)
+          .setType(AttributeType.ATTRIBUTE)
+          // Add default aggregations. See SupportedAggregationsDecorator
+          .addAllSupportedAggregations(List.of(AggregateFunction.DISTINCT_COUNT))
+          .build();
+  private static final AttributeMetadata MOCK_EVENT_DURATION_ATTRIBUTE =
+      AttributeMetadata.newBuilder()
+          .setFqn("EVENT.duration")
+          .setId("EVENT.duration")
+          .setKey("duration")
+          .setScope(AttributeScope.EVENT)
+          .setScopeString(AttributeScope.EVENT.name())
+          .setDisplayName("EVENT duration")
+          .setGroupable(false)
+          .setValueKind(AttributeKind.TYPE_INT64)
+          .setDefinition(AttributeDefinition.getDefaultInstance())
+          .setType(AttributeType.METRIC)
+          // Add default aggregations. See SupportedAggregationsDecorator
+          .addAllSupportedAggregations(
+              List.of(
+                  AggregateFunction.SUM,
+                  AggregateFunction.MIN,
+                  AggregateFunction.MAX,
+                  AggregateFunction.AVG,
+                  AggregateFunction.AVGRATE,
+                  AggregateFunction.PERCENTILE))
+          .build();
+
   @Test
   public void testFindAll() {
     RequestContext requestContext = mock(RequestContext.class);
@@ -40,25 +80,21 @@ public class AttributeServiceImplTest {
 
     Context previous = ctx.attach();
     try {
-      Collection collection = mock(Collection.class);
+      Collection collection =
+          mockCollectionReturningDocuments(
+              createMockDocument(
+                  "__root",
+                  "name",
+                  AttributeScope.EVENT,
+                  AttributeType.ATTRIBUTE,
+                  AttributeKind.TYPE_STRING),
+              createMockDocument(
+                  "__root",
+                  "duration",
+                  AttributeScope.EVENT,
+                  AttributeType.METRIC,
+                  AttributeKind.TYPE_INT64));
       StreamObserver<AttributeMetadata> responseObserver = mock(StreamObserver.class);
-
-      Document document1 =
-          createMockDocument(
-              "__root",
-              "name",
-              AttributeScope.EVENT,
-              AttributeType.ATTRIBUTE,
-              AttributeKind.TYPE_STRING);
-      Document document2 =
-          createMockDocument(
-              "__root",
-              "duration",
-              AttributeScope.EVENT,
-              AttributeType.METRIC,
-              AttributeKind.TYPE_INT64);
-      List<Document> documents = List.of(document1, document2);
-      when(collection.search(any(Query.class))).thenReturn(documents.iterator());
 
       AttributeServiceImpl attributeService = new AttributeServiceImpl(collection);
 
@@ -78,45 +114,9 @@ public class AttributeServiceImplTest {
       List<AttributeMetadata> attributeMetadataList =
           attributeMetadataArgumentCaptor.getAllValues();
       Assertions.assertEquals(2, attributeMetadataList.size());
-      AttributeMetadata attributeMetadata1 =
-          AttributeMetadata.newBuilder()
-              .setFqn("EVENT.name")
-              .setId("EVENT.name")
-              .setKey("name")
-              .setScope(AttributeScope.EVENT)
-              .setScopeString(AttributeScope.EVENT.name())
-              .setDisplayName("EVENT name")
-              .setValueKind(AttributeKind.TYPE_STRING)
-              .setDefinition(AttributeDefinition.getDefaultInstance())
-              .setGroupable(true)
-              .setType(AttributeType.ATTRIBUTE)
-              // Add default aggregations. See SupportedAggregationsDecorator
-              .addAllSupportedAggregations(List.of(AggregateFunction.DISTINCT_COUNT))
-              .build();
-      AttributeMetadata attributeMetadata2 =
-          AttributeMetadata.newBuilder()
-              .setFqn("EVENT.duration")
-              .setId("EVENT.duration")
-              .setKey("duration")
-              .setScope(AttributeScope.EVENT)
-              .setScopeString(AttributeScope.EVENT.name())
-              .setDisplayName("EVENT duration")
-              .setGroupable(false)
-              .setDefinition(AttributeDefinition.getDefaultInstance())
-              .setValueKind(AttributeKind.TYPE_INT64)
-              .setType(AttributeType.METRIC)
-              // Add default aggregations. See SupportedAggregationsDecorator
-              .addAllSupportedAggregations(
-                  List.of(
-                      AggregateFunction.SUM,
-                      AggregateFunction.MIN,
-                      AggregateFunction.MAX,
-                      AggregateFunction.AVG,
-                      AggregateFunction.AVGRATE,
-                      AggregateFunction.PERCENTILE))
-              .build();
-      Assertions.assertEquals(attributeMetadata1, attributeMetadataList.get(0));
-      Assertions.assertEquals(attributeMetadata2, attributeMetadataList.get(1));
+
+      Assertions.assertEquals(MOCK_EVENT_NAME_ATTRIBUTE, attributeMetadataList.get(0));
+      Assertions.assertEquals(MOCK_EVENT_DURATION_ATTRIBUTE, attributeMetadataList.get(1));
 
       verify(responseObserver, times(1)).onCompleted();
       verify(responseObserver, never()).onError(any(Throwable.class));
@@ -157,26 +157,21 @@ public class AttributeServiceImplTest {
 
     Context previous = ctx.attach();
     try {
-      Collection collection = mock(Collection.class);
+      Collection collection =
+          mockCollectionReturningDocuments(
+              createMockDocument(
+                  "__root",
+                  "name",
+                  AttributeScope.EVENT,
+                  AttributeType.ATTRIBUTE,
+                  AttributeKind.TYPE_STRING),
+              createMockDocument(
+                  "__root",
+                  "duration",
+                  AttributeScope.EVENT,
+                  AttributeType.METRIC,
+                  AttributeKind.TYPE_INT64));
       StreamObserver<AttributeMetadata> responseObserver = mock(StreamObserver.class);
-
-      Document document1 =
-          createMockDocument(
-              "__root",
-              "name",
-              AttributeScope.EVENT,
-              AttributeType.ATTRIBUTE,
-              AttributeKind.TYPE_STRING);
-      Document document2 =
-          createMockDocument(
-              "__root",
-              "duration",
-              AttributeScope.EVENT,
-              AttributeType.METRIC,
-              AttributeKind.TYPE_INT64);
-      List<Document> documents = List.of(document1, document2);
-      when(collection.search(any(Query.class))).thenReturn(documents.iterator());
-
       AttributeServiceImpl attributeService = new AttributeServiceImpl(collection);
 
       List<String> fqnList = List.of("EVENT.name", "EVENT.id");
@@ -249,45 +244,9 @@ public class AttributeServiceImplTest {
       List<AttributeMetadata> attributeMetadataList =
           attributeMetadataArgumentCaptor.getAllValues();
       Assertions.assertEquals(2, attributeMetadataList.size());
-      AttributeMetadata attributeMetadata1 =
-          AttributeMetadata.newBuilder()
-              .setFqn("EVENT.name")
-              .setId("EVENT.name")
-              .setKey("name")
-              .setScope(AttributeScope.EVENT)
-              .setScopeString(AttributeScope.EVENT.name())
-              .setDisplayName("EVENT name")
-              .setValueKind(AttributeKind.TYPE_STRING)
-              .setDefinition(AttributeDefinition.getDefaultInstance())
-              .setGroupable(true)
-              .setType(AttributeType.ATTRIBUTE)
-              // Add default aggregations. See SupportedAggregationsDecorator
-              .addAllSupportedAggregations(List.of(AggregateFunction.DISTINCT_COUNT))
-              .build();
-      AttributeMetadata attributeMetadata2 =
-          AttributeMetadata.newBuilder()
-              .setFqn("EVENT.duration")
-              .setId("EVENT.duration")
-              .setKey("duration")
-              .setScope(AttributeScope.EVENT)
-              .setScopeString(AttributeScope.EVENT.name())
-              .setDisplayName("EVENT duration")
-              .setGroupable(false)
-              .setValueKind(AttributeKind.TYPE_INT64)
-              .setDefinition(AttributeDefinition.getDefaultInstance())
-              .setType(AttributeType.METRIC)
-              // Add default aggregations. See SupportedAggregationsDecorator
-              .addAllSupportedAggregations(
-                  List.of(
-                      AggregateFunction.SUM,
-                      AggregateFunction.MIN,
-                      AggregateFunction.MAX,
-                      AggregateFunction.AVG,
-                      AggregateFunction.AVGRATE,
-                      AggregateFunction.PERCENTILE))
-              .build();
-      Assertions.assertEquals(attributeMetadata1, attributeMetadataList.get(0));
-      Assertions.assertEquals(attributeMetadata2, attributeMetadataList.get(1));
+
+      Assertions.assertEquals(MOCK_EVENT_NAME_ATTRIBUTE, attributeMetadataList.get(0));
+      Assertions.assertEquals(MOCK_EVENT_DURATION_ATTRIBUTE, attributeMetadataList.get(1));
 
       verify(responseObserver, times(1)).onCompleted();
       verify(responseObserver, never()).onError(any(Throwable.class));
@@ -304,86 +263,41 @@ public class AttributeServiceImplTest {
         .withValue(RequestContext.CURRENT, requestContext)
         .run(
             () -> {
-              Collection collection = mock(Collection.class);
-              StreamObserver<GetAttributesResponse> responseObserver = mock(StreamObserver.class);
+              AttributeServiceImpl attributeService =
+                  new AttributeServiceImpl(
+                      mockCollectionReturningDocuments(
+                          createMockDocument(
+                              "__root",
+                              "name",
+                              AttributeScope.EVENT,
+                              AttributeType.ATTRIBUTE,
+                              AttributeKind.TYPE_STRING),
+                          createMockDocument(
+                              "__root",
+                              "duration",
+                              AttributeScope.EVENT,
+                              AttributeType.METRIC,
+                              AttributeKind.TYPE_INT64)));
 
-              Document document1 =
-                  createMockDocument(
-                      "__root",
-                      "name",
-                      AttributeScope.EVENT,
-                      AttributeType.ATTRIBUTE,
-                      AttributeKind.TYPE_STRING);
-              Document document2 =
-                  createMockDocument(
-                      "__root",
-                      "duration",
-                      AttributeScope.EVENT,
-                      AttributeType.METRIC,
-                      AttributeKind.TYPE_INT64);
-              List<Document> documents = List.of(document1, document2);
-              when(collection.search(any(Query.class))).thenReturn(documents.iterator());
-
-              AttributeServiceImpl attributeService = new AttributeServiceImpl(collection);
-
-              List<String> keyList = List.of("name", "startTime", "duration");
-
-              AttributeMetadataFilter attributeMetadataFilter =
-                  AttributeMetadataFilter.newBuilder()
-                      .addAllKey(keyList)
-                      .addScopeString("OTHER")
-                      .build();
-
+              StreamObserver<GetAttributesResponse> mockObserver = mock(StreamObserver.class);
               attributeService.getAttributes(
-                  GetAttributesRequest.newBuilder().setFilter(attributeMetadataFilter).build(),
-                  responseObserver);
-              AttributeMetadata expectedFirstAttribute =
-                  AttributeMetadata.newBuilder()
-                      .setFqn("EVENT.name")
-                      .setId("EVENT.name")
-                      .setKey("name")
-                      .setScope(AttributeScope.EVENT)
-                      .setScopeString(AttributeScope.EVENT.name())
-                      .setDisplayName("EVENT name")
-                      .setValueKind(AttributeKind.TYPE_STRING)
-                      .setDefinition(AttributeDefinition.getDefaultInstance())
-                      .setGroupable(true)
-                      .setType(AttributeType.ATTRIBUTE)
-                      // Add default aggregations. See SupportedAggregationsDecorator
-                      .addAllSupportedAggregations(List.of(AggregateFunction.DISTINCT_COUNT))
-                      .build();
-              AttributeMetadata expectedSecondAttribute =
-                  AttributeMetadata.newBuilder()
-                      .setFqn("EVENT.duration")
-                      .setId("EVENT.duration")
-                      .setKey("duration")
-                      .setScope(AttributeScope.EVENT)
-                      .setScopeString(AttributeScope.EVENT.name())
-                      .setDisplayName("EVENT duration")
-                      .setGroupable(false)
-                      .setValueKind(AttributeKind.TYPE_INT64)
-                      .setDefinition(AttributeDefinition.getDefaultInstance())
-                      .setType(AttributeType.METRIC)
-                      // Add default aggregations. See SupportedAggregationsDecorator
-                      .addAllSupportedAggregations(
-                          List.of(
-                              AggregateFunction.SUM,
-                              AggregateFunction.MIN,
-                              AggregateFunction.MAX,
-                              AggregateFunction.AVG,
-                              AggregateFunction.AVGRATE,
-                              AggregateFunction.PERCENTILE))
-                      .build();
+                  GetAttributesRequest.newBuilder()
+                      .setFilter(
+                          AttributeMetadataFilter.newBuilder()
+                              .addKey(MOCK_EVENT_NAME_ATTRIBUTE.getKey())
+                              .addKey(MOCK_EVENT_DURATION_ATTRIBUTE.getKey()))
+                      .build(),
+                  mockObserver);
 
-              verify(responseObserver, times(1))
+              verify(mockObserver, times(1))
                   .onNext(
                       GetAttributesResponse.newBuilder()
-                          .addAttributes(expectedFirstAttribute)
-                          .addAttributes(expectedSecondAttribute)
+                          .addAttributes(MOCK_EVENT_NAME_ATTRIBUTE)
+                          .addAttributes(MOCK_EVENT_DURATION_ATTRIBUTE)
                           .build());
 
-              verify(responseObserver, times(1)).onCompleted();
-              verify(responseObserver, never()).onError(any(Throwable.class));
+              verify(mockObserver, times(1)).onCompleted();
+              verify(mockObserver, never()).onError(any());
             });
   }
 
@@ -410,6 +324,12 @@ public class AttributeServiceImplTest {
     } finally {
       ctx.detach(previous);
     }
+  }
+
+  private Collection mockCollectionReturningDocuments(Document... documents) {
+    Collection collection = mock(Collection.class);
+    when(collection.search(any(Query.class))).thenReturn(Iterators.forArray(documents));
+    return collection;
   }
 
   private Document createMockDocument(

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -57,8 +57,9 @@ dependencies {
   implementation(project(":attribute-service-impl"))
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.6.0")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
+  implementation("io.grpc:grpc-services:1.40.0")
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
@@ -102,7 +103,9 @@ tasks.jacocoIntegrationTestReport {
 hypertraceDocker {
   defaultImage {
     javaApplication {
-      port.set(9012)
+      ports.add(9012)
+      adminPort.set(9013)
+      healthCheck.set("HEALTHCHECK --interval=2s --start-period=15s --timeout=2s CMD /bin/grpc_health_probe -addr=:9012 -connect-timeout=100ms -rpc-timeout=150ms")
     }
   }
 }

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
   implementation(project(":attribute-service-impl"))
 
   implementation("org.hypertrace.core.serviceframework:platform-service-framework:0.1.28")
-  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.4.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-server-utils:0.5.2")
   implementation("org.hypertrace.core.documentstore:document-store:0.5.4")
 
   // Logging
@@ -65,7 +65,7 @@ dependencies {
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1")
 
   // GRPC
-  runtimeOnly("io.grpc:grpc-netty:1.36.1")
+  runtimeOnly("io.grpc:grpc-netty:1.40.0")
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.61.Final") {
       because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1089809")

--- a/caching-attribute-service-client/build.gradle.kts
+++ b/caching-attribute-service-client/build.gradle.kts
@@ -8,12 +8,12 @@ plugins {
 dependencies {
   api(project(":attribute-service-api"))
   api("io.reactivex.rxjava3:rxjava:3.0.5")
-  api("io.grpc:grpc-api:1.36.1")
+  api("io.grpc:grpc-api:1.40.0")
 
-  implementation("io.grpc:grpc-stub:1.36.1")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.4.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.4.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.4.0")
+  implementation("io.grpc:grpc-stub:1.40.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")
   implementation("com.google.guava:guava:30.1.1-jre")
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")
@@ -22,7 +22,7 @@ dependencies {
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
-  testImplementation("io.grpc:grpc-core:1.36.1")
+  testImplementation("io.grpc:grpc-core:1.40.0")
   testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.14.1")
 }
 

--- a/caching-attribute-service-client/build.gradle.kts
+++ b/caching-attribute-service-client/build.gradle.kts
@@ -11,9 +11,9 @@ dependencies {
   api("io.grpc:grpc-api:1.40.0")
 
   implementation("io.grpc:grpc-stub:1.40.0")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.5.2")
-  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.5.2")
-  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.5.2")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-utils:0.6.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-client-rx-utils:0.6.0")
+  implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.6.0")
   implementation("com.google.guava:guava:30.1.1-jre")
   annotationProcessor("org.projectlombok:lombok:1.18.20")
   compileOnly("org.projectlombok:lombok:1.18.20")

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -54,9 +54,6 @@ spec:
             - name: grpc-port
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
-            - name: health-port
-              containerPort: {{ .Values.containerHealthProbePort }}
-              protocol: TCP
           env:
             - name: SERVICE_NAME
               value: "{{ .Chart.Name }}"
@@ -75,13 +72,12 @@ spec:
           livenessProbe:
             initialDelaySeconds: {{ int .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ int .Values.livenessProbe.periodSeconds }}
-            tcpSocket:
-              port: grpc-port
+            exec:
+              command: [ "/bin/grpc_health_probe", "-addr=:{{ .Values.containerHealthProbePort }}", "-connect-timeout=100ms", "-rpc-timeout=150ms" ]
           readinessProbe:
             initialDelaySeconds: {{ int .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ int .Values.readinessProbe.periodSeconds }}
-            httpGet:
-              path: /health
-              port: {{ .Values.containerHealthProbePort }}
+            exec:
+              command: [ "/bin/grpc_health_probe", "-addr=:{{ .Values.containerHealthProbePort }}", "-connect-timeout=100ms", "-rpc-timeout=150ms" ]
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,7 +12,7 @@ image:
 imagePullSecrets: {}
 
 containerPort: 9012
-containerHealthProbePort: 9013
+containerHealthProbePort: 9012
 
 service:
   type: ClusterIP


### PR DESCRIPTION
## Description
This combines two different changes in an attempt to be a more well behaved server. It cleans up (or actually adds, since this server was missing it entirely) server shutdown, and it adds a real grpc service as a health check as described at https://github.com/grpc/grpc/blob/master/doc/health-checking.md

The idea is to get a check that better reflects the actual health of the service, as the current check continues to serve OK when the grpc server has gone non-responsive. It also appropriately waits to mark healthy until the server is actually ready, and offline _before_ shutdown, hopefully leading to smoother rollouts/upgrades.

Depends on https://github.com/hypertrace/docker-java-base/pull/9

### Testing
Built and tested this change locally in docker
