### PR TITLE
fix: use correct probes

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -74,6 +74,7 @@ spec:
               mountPath: /var/{{ .Chart.Name }}/log
           livenessProbe:
             periodSeconds: {{ int .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ int .Values.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: {{ .Values.containerHealthProbePort }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -24,6 +24,7 @@ javaOpts: "-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=75.0 -XX:MaxDirect
 
 livenessProbe:
   periodSeconds: 5
+  failureThreshold: 2
 startupProbe:
   periodSeconds: 5
   failureThreshold: 24


### PR DESCRIPTION
## Description
The main change in this PR is to replace our probing pattern. Previously (before 0.13.0) we used a static initial delay for liveness, by default 10s, upon which we began to check the tcp port for liveness. In addition, we had a readiness probe that checked the admin http server for readiness. This was close to right (the readiness probe meant the http server, not the grpc server had started - but close), but was problematic because 
- the readiness check was reflecting the admin server, rather than the actually grpc server that serves data, so the checks were not reflecting the actual health
- the errors that were bringing down traffic to the grpc server are not recoverable - usually resource exhaustion - so even if the readiness probe was reflecting the state correctly, it would not restart the pod as we'd like. The liveness probe which would do that is just looking at a port so not particularly meaningful.
- used a static delay, potentially leading to longer startups

In other words, the behavior we really wanted was that of the liveness probe - the problem is that if failed on startup, we'll get into a crash loop - so it needs enough of a grace period to ensure a full startup. Unfortunately, the server can take wildly different times to startup depending on instrumentation and resource allocation. So we could change the startup delay to be really large, but then we're really setting a _minimum_ startup time, rather than _maximum_.

In this PR, by using a startup probe we now have the following behavior (values are configurable but defaulted):
Immediately start checking if the grpc server is healthy every 5s on startup, continuing for up to 2m. Once the server is marked live, it can begin serving traffic and we'll check the status of its grpc server every 5s to make sure it's still live. If it fails 2 consecutive checks, we'll restart the pod.

Other changes:
- Replaced JAVA_TOOL_OPTIONS with JAVA_OPTS, better practice

### Testing
I deployed this change to a local k8s cluster to verify correctness.