### PR TITLE
Internal flag in attribute_metadata

### DIFF
--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
@@ -100,6 +100,7 @@ message AttributeMetadata {
   bool groupable = 15;
   AttributeDefinition definition = 16;
   string scope_string = 17;
+  bool is_internal = 18;
 }
 
 message AttributeSourceMetadata {

--- a/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
+++ b/attribute-service-api/src/main/proto/org/hypertrace/core/attribute/service/v1/attribute_metadata.proto
@@ -100,7 +100,7 @@ message AttributeMetadata {
   bool groupable = 15;
   AttributeDefinition definition = 16;
   string scope_string = 17;
-  bool is_internal = 18;
+  bool internal = 18;
 }
 
 message AttributeSourceMetadata {

--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -251,8 +251,8 @@ public class AttributeMetadataModel implements Document {
     return isInternal;
   }
 
-  public void setIsInternal(boolean is_internal) {
-    this.isInternal = is_internal;
+  public void setIsInternal(boolean isInternal) {
+    this.isInternal = isInternal;
   }
 
   public AttributeMetadata toDTO() {

--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -343,7 +343,7 @@ public class AttributeMetadataModel implements Document {
         + sources
         + ", metadata="
         + metadata
-        + ", Internal="
+        + ", internal="
         + internal
         + '}';
   }

--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -74,8 +74,7 @@ public class AttributeMetadataModel implements Document {
   @JsonDeserialize(using = AttributeDefinitionDeserializer.class)
   private AttributeDefinition definition = AttributeDefinition.getDefaultInstance();
 
-  @JsonProperty(value = "is_internal")
-  private boolean isInternal;
+  private boolean internal;
 
   protected AttributeMetadataModel() {}
 
@@ -104,7 +103,7 @@ public class AttributeMetadataModel implements Document {
                     Map.Entry::getKey,
                     stringAttributeSourceMetadataEntry ->
                         stringAttributeSourceMetadataEntry.getValue().getSourceMetadataMap())));
-    attributeMetadataModel.setIsInternal(attributeMetadata.getIsInternal());
+    attributeMetadataModel.setInternal(attributeMetadata.getInternal());
     return attributeMetadataModel;
   }
 
@@ -247,12 +246,12 @@ public class AttributeMetadataModel implements Document {
     this.definition = definition;
   }
 
-  public boolean getIsInternal() {
-    return isInternal;
+  public boolean getInternal() {
+    return internal;
   }
 
-  public void setIsInternal(boolean isInternal) {
-    this.isInternal = isInternal;
+  public void setInternal(boolean isInternal) {
+    this.internal = isInternal;
   }
 
   public AttributeMetadata toDTO() {
@@ -286,7 +285,7 @@ public class AttributeMetadataModel implements Document {
                                     .putAllSourceMetadata(stringMapEntry.getValue())
                                     .build())))
             .setDefinition(this.definition)
-            .setIsInternal(isInternal);
+            .setInternal(internal);
 
     if (unit != null) {
       builder.setUnit(unit);
@@ -344,8 +343,8 @@ public class AttributeMetadataModel implements Document {
         + sources
         + ", metadata="
         + metadata
-        + ", IsInternal="
-        + isInternal
+        + ", Internal="
+        + internal
         + '}';
   }
 
@@ -374,7 +373,7 @@ public class AttributeMetadataModel implements Document {
         && Objects.equals(metadata, that.metadata)
         && Objects.equals(definition, that.definition)
         && Objects.equals(scopeString, that.scopeString)
-        && Objects.equals(isInternal, that.isInternal);
+        && Objects.equals(internal, that.internal);
   }
 
   @Override
@@ -396,7 +395,7 @@ public class AttributeMetadataModel implements Document {
         metadata,
         definition,
         scopeString,
-        isInternal);
+        internal);
   }
 
   private static class ProtobufMessageSerializer extends JsonSerializer<Message> {

--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -74,6 +74,9 @@ public class AttributeMetadataModel implements Document {
   @JsonDeserialize(using = AttributeDefinitionDeserializer.class)
   private AttributeDefinition definition = AttributeDefinition.getDefaultInstance();
 
+  @JsonProperty(value = "is_internal")
+  private boolean isInternal;
+
   protected AttributeMetadataModel() {}
 
   public static AttributeMetadataModel fromDTO(AttributeMetadata attributeMetadata) {
@@ -101,6 +104,7 @@ public class AttributeMetadataModel implements Document {
                     Map.Entry::getKey,
                     stringAttributeSourceMetadataEntry ->
                         stringAttributeSourceMetadataEntry.getValue().getSourceMetadataMap())));
+    attributeMetadataModel.setIsInternal(attributeMetadata.getIsInternal());
     return attributeMetadataModel;
   }
 
@@ -243,6 +247,14 @@ public class AttributeMetadataModel implements Document {
     this.definition = definition;
   }
 
+  public boolean getIsInternal() {
+    return isInternal;
+  }
+
+  public void setIsInternal(boolean is_internal) {
+    this.isInternal = is_internal;
+  }
+
   public AttributeMetadata toDTO() {
     return toDTOBuilder().build();
   }
@@ -273,7 +285,8 @@ public class AttributeMetadataModel implements Document {
                                 AttributeSourceMetadata.newBuilder()
                                     .putAllSourceMetadata(stringMapEntry.getValue())
                                     .build())))
-            .setDefinition(this.definition);
+            .setDefinition(this.definition)
+            .setIsInternal(isInternal);
 
     if (unit != null) {
       builder.setUnit(unit);
@@ -331,6 +344,8 @@ public class AttributeMetadataModel implements Document {
         + sources
         + ", metadata="
         + metadata
+        + ", IsInternal="
+        + isInternal
         + '}';
   }
 
@@ -358,7 +373,8 @@ public class AttributeMetadataModel implements Document {
         && Objects.equals(sources, that.sources)
         && Objects.equals(metadata, that.metadata)
         && Objects.equals(definition, that.definition)
-        && Objects.equals(scopeString, that.scopeString);
+        && Objects.equals(scopeString, that.scopeString)
+        && Objects.equals(isInternal, that.isInternal);
   }
 
   @Override
@@ -379,7 +395,8 @@ public class AttributeMetadataModel implements Document {
         sources,
         metadata,
         definition,
-        scopeString);
+        scopeString,
+        isInternal);
   }
 
   private static class ProtobufMessageSerializer extends JsonSerializer<Message> {

--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -250,8 +250,8 @@ public class AttributeMetadataModel implements Document {
     return internal;
   }
 
-  public void setInternal(boolean isInternal) {
-    this.internal = isInternal;
+  public void setInternal(boolean internal) {
+    this.internal = internal;
   }
 
   public AttributeMetadata toDTO() {

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
@@ -36,7 +36,7 @@ public class AttributeMetadataModelTest {
         AttributeDefinition.newBuilder()
             .setProjection(Projection.newBuilder().setAttributeId("test"))
             .build());
-    attributeMetadataModel.setIsInternal(true);
+    attributeMetadataModel.setInternal(true);
 
     String json = attributeMetadataModel.toJson();
     String expectedJson =
@@ -52,12 +52,12 @@ public class AttributeMetadataModelTest {
             + "\"onlyAggregationsAllowed\":false,"
             + "\"sources\":[],"
             + "\"definition\":{\"projection\":{\"attributeId\":\"test\"}},"
+            + "\"internal\":true,"
             + "\"id\":\"EVENT.key\","
             + "\"value_kind\":\"TYPE_STRING\","
             + "\"display_name\":\"Some Name\","
             + "\"scope_string\":\"EVENT\","
-            + "\"tenant_id\":\"tenantId\","
-            + "\"is_internal\":true"
+            + "\"tenant_id\":\"tenantId\""
             + "}";
     Assertions.assertEquals(expectedJson, json);
     AttributeMetadataModel deserializedModel = AttributeMetadataModel.fromJson(json);
@@ -248,12 +248,12 @@ public class AttributeMetadataModelTest {
             + "\"onlyAggregationsAllowed\":false,"
             + "\"sources\":[],"
             + "\"definition\":{},"
+            + "\"internal\":false,"
             + "\"id\":\"EVENT.key\","
             + "\"value_kind\":\"TYPE_STRING\","
             + "\"display_name\":\"Display\","
             + "\"scope_string\":\"EVENT\","
-            + "\"tenant_id\":null,"
-            + "\"is_internal\":false"
+            + "\"tenant_id\":null"
             + "}";
     Assertions.assertEquals(expectedJson, modelFromMetadataWithoutDefinition.toJson());
   }

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
@@ -36,6 +36,7 @@ public class AttributeMetadataModelTest {
         AttributeDefinition.newBuilder()
             .setProjection(Projection.newBuilder().setAttributeId("test"))
             .build());
+    attributeMetadataModel.setIsInternal(true);
 
     String json = attributeMetadataModel.toJson();
     String expectedJson =
@@ -55,7 +56,8 @@ public class AttributeMetadataModelTest {
             + "\"value_kind\":\"TYPE_STRING\","
             + "\"display_name\":\"Some Name\","
             + "\"scope_string\":\"EVENT\","
-            + "\"tenant_id\":\"tenantId\""
+            + "\"tenant_id\":\"tenantId\","
+            + "\"is_internal\":true"
             + "}";
     Assertions.assertEquals(expectedJson, json);
     AttributeMetadataModel deserializedModel = AttributeMetadataModel.fromJson(json);
@@ -250,7 +252,9 @@ public class AttributeMetadataModelTest {
             + "\"value_kind\":\"TYPE_STRING\","
             + "\"display_name\":\"Display\","
             + "\"scope_string\":\"EVENT\","
-            + "\"tenant_id\":null}";
+            + "\"tenant_id\":null,"
+            + "\"is_internal\":false"
+            + "}";
     Assertions.assertEquals(expectedJson, modelFromMetadataWithoutDefinition.toJson());
   }
 

--- a/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
+++ b/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
@@ -13,7 +13,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.hypertrace.core.attribute.service.client.AttributeServiceClient;
+import org.hypertrace.core.attribute.service.v1.AggregateFunction;
 import org.hypertrace.core.attribute.service.v1.AttributeCreateRequest;
+import org.hypertrace.core.attribute.service.v1.AttributeDefinition;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadataFilter;
@@ -124,6 +126,40 @@ public class AttributeServiceTest {
     } else {
       client.create(TEST_TENANT_ID, attributeCreateRequest);
     }
+  }
+
+  @Test
+  public void testCheckValidAttributeMetadata() {
+    AttributeMetadata expectedAttributeMetadata =
+        AttributeMetadata.newBuilder()
+            .setFqn("name-1")
+            .setValueKind(AttributeKind.TYPE_STRING)
+            .setKey("key-1")
+            .setDisplayName("displayname-1")
+            .setScope(AttributeScope.EVENT)
+            .setMaterialized(false)
+            .setUnit("unit-1")
+            .setType(AttributeType.ATTRIBUTE)
+            .addAllLabels(List.of("label-1", "label-2"))
+            .addAllSupportedAggregations(List.of(AggregateFunction.SUM, AggregateFunction.AVG))
+            .setOnlyAggregationsAllowed(true)
+            .addSources(AttributeSource.EDS)
+            .setId("EVENT.key-1")
+            .setGroupable(true)
+            .setDefinition(AttributeDefinition.newBuilder().setSourcePath("sourcepath-1"))
+            .setScopeString(AttributeScope.EVENT.name())
+            .setInternal(true)
+            .build();
+
+    AttributeCreateRequest request =
+        AttributeCreateRequest.newBuilder().addAttributes(expectedAttributeMetadata).build();
+    client.create(requestHeaders, request);
+
+    List<AttributeMetadata> attributeMetadataList =
+        Streams.stream(
+                client.findAttributes(requestHeaders, AttributeMetadataFilter.getDefaultInstance()))
+            .collect(Collectors.toList());
+    assertEquals(expectedAttributeMetadata, attributeMetadataList.get(0));
   }
 
   @Test

--- a/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
+++ b/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
@@ -159,7 +159,7 @@ public class AttributeServiceTest {
         Streams.stream(
                 client.findAttributes(requestHeaders, AttributeMetadataFilter.getDefaultInstance()))
             .collect(Collectors.toList());
-    assertEquals(expectedAttributeMetadata, attributeMetadataList.get(0));
+    assertEquals(List.of(expectedAttributeMetadata), attributeMetadataList);
   }
 
   @Test


### PR DESCRIPTION
This flag will tell whether the attribute is meant for internal use only or it can be used externally as well (i.e. can be exposed to the UI).