### PR TITLE
fix: add backwards compatibility to internal filter

### DIFF
--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/AttributeServiceImpl.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/AttributeServiceImpl.java
@@ -388,8 +388,13 @@ public class AttributeServiceImpl extends AttributeServiceGrpc.AttributeServiceI
     }
 
     if (attributeMetadataFilter.hasInternal()) {
-      andFilters.add(
-          new Filter(Op.EQ, ATTRIBUTE_INTERNAL_KEY, attributeMetadataFilter.getInternal()));
+      Filter internalFilter =
+          new Filter(Op.EQ, ATTRIBUTE_INTERNAL_KEY, attributeMetadataFilter.getInternal());
+      if (!attributeMetadataFilter.getInternal()) {
+        // For backwards compatibility, treat an attribute missing internal attribute as external
+        internalFilter = internalFilter.or(new Filter(Op.NOT_EXISTS, ATTRIBUTE_INTERNAL_KEY, null));
+      }
+      andFilters.add(internalFilter);
     }
 
     Filter queryFilter = new Filter();


### PR DESCRIPTION
## Description
The previous implementation applied the internal attribute filter always, which works for newly written attributes but not for legacy attributes that are missing that key. This change adds backwards compatibility.

### Testing
This only applies to legacy data so difficult to test without a pre-seeded DB. Verified manually against a legacy db.
