### PR TITLE
fix: bring in latest config to fix service name attribute

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.1.0
 dependencies:
   - name: config-bootstrapper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.2.21
+    version: 0.2.22


### PR DESCRIPTION
## Description
See https://github.com/hypertrace/config-bootstrapper/pull/65