### PR TITLE
chore: update log4j

### DIFF
--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.junit.jupiter:junit-jupiter:5.7.1")
-  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 }
 
 tasks.test {

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
 
   // Logging
   implementation("org.slf4j:slf4j-api:1.7.30")
-  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 
   // GRPC
   runtimeOnly("io.grpc:grpc-netty:1.42.0")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
   constraints {
     runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
     runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
+  }
 
   // Config
   implementation("com.typesafe:config:1.4.1")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -69,13 +69,8 @@ dependencies {
   // GRPC
   runtimeOnly("io.grpc:grpc-netty:1.42.0")
   constraints {
-    runtimeOnly("io.netty:netty-codec-http2:4.1.68.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1089809")
-    }
-    runtimeOnly("io.netty:netty-handler-proxy:4.1.68.Final") {
-      because("https://snyk.io/vuln/SNYK-JAVA-IONETTY-1089809")
-    }
-  }
+    runtimeOnly("io.netty:netty-codec-http2:4.1.71.Final")
+    runtimeOnly("io.netty:netty-handler-proxy:4.1.71.Final")
 
   // Config
   implementation("com.typesafe:config:1.4.1")

--- a/caching-attribute-service-client/build.gradle.kts
+++ b/caching-attribute-service-client/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
   testImplementation("org.mockito:mockito-core:3.8.0")
   testImplementation("org.mockito:mockito-junit-jupiter:3.8.0")
   testImplementation("io.grpc:grpc-core:1.42.0")
-  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.15.0")
+  testImplementation("org.apache.logging.log4j:log4j-slf4j-impl:2.16.0")
 }
 
 tasks.test {


### PR DESCRIPTION
## Description
Not known to be vulnerable in current config, but upgrading log4j due to https://nvd.nist.gov/vuln/detail/CVE-2021-45046 out of abundance of caution.