### PR TITLE
chore: fix vulnerabilities in attribute service

### DIFF
--- a/attribute-service-api/build.gradle.kts
+++ b/attribute-service-api/build.gradle.kts
@@ -15,7 +15,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.21.1"
+    artifact = "com.google.protobuf:protoc:3.21.12"
   }
   plugins {
     id("grpc_java") {

--- a/attribute-service-api/build.gradle.kts
+++ b/attribute-service-api/build.gradle.kts
@@ -15,7 +15,7 @@ val generateLocalGoGrpcFiles = false
 
 protobuf {
   protoc {
-    artifact = "com.google.protobuf:protoc:3.15.6"
+    artifact = "com.google.protobuf:protoc:3.21.1"
   }
   plugins {
     id("grpc_java") {
@@ -57,7 +57,7 @@ sourceSets {
 }
 
 dependencies {
-  api(platform("io.grpc:grpc-bom:1.44.0"))
+  api(platform("io.grpc:grpc-bom:1.50.0"))
   api("io.grpc:grpc-stub")
   api("io.grpc:grpc-protobuf")
 

--- a/attribute-service-factory/build.gradle.kts
+++ b/attribute-service-factory/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.37")
+  api("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.49")
 
   // Only required because AttributeService constructor test overload uses a doc store API
   compileOnly("org.hypertrace.core.documentstore:document-store:0.7.20")

--- a/attribute-service-impl/build.gradle.kts
+++ b/attribute-service-impl/build.gradle.kts
@@ -11,10 +11,10 @@ dependencies {
   implementation("org.hypertrace.core.documentstore:document-store:0.7.20")
   implementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.9.0")
 
-  implementation("com.fasterxml.jackson.core:jackson-databind:2.13.2.2")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.14.2")
   implementation("com.typesafe:config:1.4.1")
   implementation("org.slf4j:slf4j-api:1.7.32")
-  implementation("com.google.protobuf:protobuf-java-util:3.19.2")
+  implementation("com.google.protobuf:protobuf-java-util:3.21.12")
   implementation("com.google.guava:guava:31.1-jre")
 
   testImplementation("org.mockito:mockito-core:4.2.0")

--- a/attribute-service/build.gradle.kts
+++ b/attribute-service/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.integrationTest {
 
 dependencies {
   implementation(project(":attribute-service-factory"))
-  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.37")
+  implementation("org.hypertrace.core.serviceframework:platform-grpc-service-framework:0.1.49")
   runtimeOnly("org.apache.logging.log4j:log4j-slf4j-impl:2.17.1")
   runtimeOnly("io.grpc:grpc-netty")
 
@@ -63,7 +63,7 @@ dependencies {
   integrationTestImplementation("org.junit.jupiter:junit-jupiter:5.8.2")
   integrationTestImplementation("com.google.guava:guava:31.1-jre")
   integrationTestImplementation(project(":attribute-service-client"))
-  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.37")
+  integrationTestImplementation("org.hypertrace.core.serviceframework:integrationtest-service-framework:0.1.49")
   integrationTestImplementation("org.hypertrace.core.grpcutils:grpc-context-utils:0.9.0")
 }
 


### PR DESCRIPTION
Fix vulnerabilities -

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Local Snyk policy: found
Licenses:          enabled

✔ Tested /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-projection-functions
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

✔ Tested 17 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 32 dependencies for known issues, found 3 issues, 6 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-projection-registry
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 76 dependencies for known issues, found 4 issues, 8 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Improper Certificate Validation [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-1042268] in io.netty:netty-handler@4.1.79.Final
    introduced by io.grpc:grpc-netty@1.50.0 > io.netty:netty-codec-http2@4.1.79.Final > io.netty:netty-handler@4.1.79.Final and 1 other path(s)
  No upgrade or patch available



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 18 dependencies for known issues, found 3 issues, 6 vulnerable paths.


Issues to fix by upgrading:

  Upgrade io.grpc:grpc-protobuf@1.44.0 to io.grpc:grpc-protobuf@1.44.2 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by io.grpc:grpc-protobuf@1.44.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service-api
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 19 dependencies for known issues, found 3 issues, 6 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.attribute.service:attribute-service-api@0.14.17 > io.grpc:grpc-protobuf@1.45.1 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service-client
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 27 dependencies for known issues, found 3 issues, 6 vulnerable paths.


Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3040284] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167772] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLEPROTOBUF-3167774] in com.google.protobuf:protobuf-java@3.19.2
    introduced by org.hypertrace.core.serviceframework:platform-grpc-service-framework@0.1.37 > io.grpc:grpc-services@1.47.0 > io.grpc:grpc-protobuf@1.47.0 > com.google.protobuf:protobuf-java@3.19.2 and 1 other path(s)
  This issue was fixed in versions: 3.16.3, 3.19.6, 3.20.3, 3.21.7



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service-factory
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Tested 52 dependencies for known issues, found 3 issues, 3 vulnerable paths.


Issues to fix by upgrading:

  Upgrade com.fasterxml.jackson.core:jackson-databind@2.13.2.2 to com.fasterxml.jackson.core:jackson-databind@2.13.4.2 to fix
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038426] in com.fasterxml.jackson.core:jackson-databind@2.13.2.2
    introduced by com.fasterxml.jackson.core:jackson-databind@2.13.2.2
  ✗ Denial of Service (DoS) [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-3038424] in com.fasterxml.jackson.core:jackson-databind@2.13.2.2
    introduced by com.fasterxml.jackson.core:jackson-databind@2.13.2.2

  Upgrade com.google.protobuf:protobuf-java-util@3.19.2 to com.google.protobuf:protobuf-java-util@3.20.0 to fix
  ✗ Deserialization of Untrusted Data [Medium Severity][https://security.snyk.io/vuln/SNYK-JAVA-COMGOOGLECODEGSON-1730327] in com.google.code.gson:gson@2.8.6
    introduced by com.google.protobuf:protobuf-java-util@3.19.2 > com.google.code.gson:gson@2.8.6



Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service-impl
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/attribute-service-tenant-api
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

✔ Tested 15 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

-------------------------------------------------------

Testing /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service...

Organization:      saxenakshitiz
Package manager:   gradle
Target file:       build.gradle.kts
Project name:      attribute-service/caching-attribute-service-client
Open source:       no
Project path:      /Users/kshitizsaxena/SourceCode/hypertrace/attribute-service
Licenses:          enabled

✔ Tested 47 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.


Tested 10 projects, 6 contained vulnerable paths.