### PR TITLE
ci: restore autobuild for code scanning

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,8 +35,10 @@ jobs:
           languages: ${{ matrix.language }}
 
       - uses: hypertrace/github-actions/gradle@main
-        with:
-          args: assemble
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Unit test and other verification
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: check jacocoTestReport
 
       - name: Upload coverage to Codecov
@@ -25,10 +25,10 @@ jobs:
         with:
           name: unit test reports
           flags: unit
-  
+
       - name: Integration test
         uses: hypertrace/github-actions/gradle@main
-        with: 
+        with:
           args: jacocoIntegrationTestReport
 
       - name: Upload coverage to Codecov
@@ -40,7 +40,7 @@ jobs:
       - name: copy test reports
         uses: hypertrace/github-actions/gradle@main
         if: always()
-        with: 
+        with:
           args: copyAllReports --output-dir=/tmp/test-reports
 
       - name: Archive test reports


### PR DESCRIPTION
## Description

Not sure why autobuild works and the hand build doesn't, but when compiling directly GH can't seem to find class files. The reason for the switch was to use the gradle action cache, so setting that up with a no-arg run beforehand now instead.