### PR TITLE
fix: attribute definition should be unset if default

### DIFF
--- a/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
+++ b/attribute-service-impl/src/main/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModel.java
@@ -285,12 +285,14 @@ public class AttributeMetadataModel implements Document {
                                 AttributeSourceMetadata.newBuilder()
                                     .putAllSourceMetadata(stringMapEntry.getValue())
                                     .build())))
-            .setDefinition(this.definition)
             .setInternal(internal)
             .setCustom(!ROOT_TENANT_ID.equals(tenantId));
 
     if (unit != null) {
       builder.setUnit(unit);
+    }
+    if (!definition.equals(AttributeDefinition.getDefaultInstance())) {
+      builder.setDefinition(definition);
     }
 
     return builder;

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/AttributeServiceImplTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/AttributeServiceImplTest.java
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import org.hypertrace.core.attribute.service.v1.AggregateFunction;
-import org.hypertrace.core.attribute.service.v1.AttributeDefinition;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadataFilter;
@@ -45,7 +44,6 @@ public class AttributeServiceImplTest {
           .setScopeString(AttributeScope.EVENT.name())
           .setDisplayName("EVENT name")
           .setValueKind(AttributeKind.TYPE_STRING)
-          .setDefinition(AttributeDefinition.getDefaultInstance())
           .setGroupable(true)
           .setType(AttributeType.ATTRIBUTE)
           // Add default aggregations. See SupportedAggregationsDecorator
@@ -60,7 +58,6 @@ public class AttributeServiceImplTest {
           .setScopeString(AttributeScope.EVENT.name())
           .setDisplayName("EVENT type")
           .setValueKind(AttributeKind.TYPE_STRING)
-          .setDefinition(AttributeDefinition.getDefaultInstance())
           .setGroupable(true)
           .setType(AttributeType.ATTRIBUTE)
           // Add default aggregations. See SupportedAggregationsDecorator
@@ -77,7 +74,6 @@ public class AttributeServiceImplTest {
           .setDisplayName("EVENT duration")
           .setGroupable(false)
           .setValueKind(AttributeKind.TYPE_INT64)
-          .setDefinition(AttributeDefinition.getDefaultInstance())
           .setType(AttributeType.METRIC)
           // Add default aggregations. See SupportedAggregationsDecorator
           .addAllSupportedAggregations(

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/delegate/AttributeUpdaterImplTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/delegate/AttributeUpdaterImplTest.java
@@ -14,7 +14,6 @@ import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.stream.IntStream;
-import org.hypertrace.core.attribute.service.v1.AttributeDefinition;
 import org.hypertrace.core.attribute.service.v1.AttributeKind;
 import org.hypertrace.core.attribute.service.v1.AttributeMetadata;
 import org.hypertrace.core.attribute.service.v1.AttributeScope;
@@ -66,7 +65,6 @@ class AttributeUpdaterImplTest {
             .setUnit("ms")
             .setValueKind(AttributeKind.TYPE_STRING)
             .addSupportedAggregations(DISTINCT_COUNT)
-            .setDefinition(AttributeDefinition.getDefaultInstance())
             .setGroupable(true)
             .setInternal(true)
             .setCustom(true)

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
@@ -82,7 +82,6 @@ public class AttributeMetadataModelTest {
             .setType(AttributeType.ATTRIBUTE)
             .setUnit("ms")
             .setValueKind(AttributeKind.TYPE_STRING)
-            .setDefinition(AttributeDefinition.getDefaultInstance())
             .putAllMetadata(
                 Collections.singletonMap(
                     AttributeSource.EDS.name(),
@@ -271,7 +270,6 @@ public class AttributeMetadataModelTest {
             .setDisplayName("Some Name")
             .setValueKind(AttributeKind.TYPE_BOOL)
             .setType(AttributeType.ATTRIBUTE)
-            .setDefinition(AttributeDefinition.getDefaultInstance())
             .setCustom(true)
             .build();
 

--- a/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
+++ b/attribute-service-impl/src/test/java/org/hypertrace/core/attribute/service/model/AttributeMetadataModelTest.java
@@ -1,6 +1,7 @@
 package org.hypertrace.core.attribute.service.model;
 
 import static org.hypertrace.core.attribute.service.utils.tenant.TenantUtils.ROOT_TENANT_ID;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -118,9 +119,9 @@ public class AttributeMetadataModelTest {
 
     // backward compatibility test, no groupable field, BOOL type
     AttributeMetadataModel deserializedModel = AttributeMetadataModel.fromJson(json);
-    Assertions.assertFalse(deserializedModel.isGroupable());
+    assertFalse(deserializedModel.isGroupable());
     AttributeMetadata metadata = deserializedModel.toDTO();
-    Assertions.assertFalse(metadata.getGroupable());
+    assertFalse(metadata.getGroupable());
 
     json =
         "{"
@@ -192,9 +193,9 @@ public class AttributeMetadataModelTest {
 
     // override default, STRING type
     deserializedModel = AttributeMetadataModel.fromJson(json);
-    Assertions.assertFalse(deserializedModel.isGroupable());
+    assertFalse(deserializedModel.isGroupable());
     metadata = deserializedModel.toDTO();
-    Assertions.assertFalse(metadata.getGroupable());
+    assertFalse(metadata.getGroupable());
   }
 
   @Test
@@ -456,5 +457,34 @@ public class AttributeMetadataModelTest {
 
     final AttributeMetadata metadata = AttributeMetadataModel.fromJson(json).toDTO();
     Assertions.assertEquals(expectedMetadata, metadata);
+  }
+
+  @Test
+  void testCustomAttributeDefinitionIsUnsetIfMissingOrDefaultInModel() throws IOException {
+    final String missingDefinitionJson =
+        "{"
+            + "\"fqn\":\"fqn\","
+            + "\"type\":\"ATTRIBUTE\","
+            + "\"display_name\":\"Some Name\","
+            + "\"key\":\"key\","
+            + "\"id\":\"EVENT.key\","
+            + "\"value_kind\":\"TYPE_STRING\","
+            + "\"scope_string\":\"EVENT\""
+            + "}";
+    assertFalse(AttributeMetadataModel.fromJson(missingDefinitionJson).toDTO().hasDefinition());
+
+    final String defaultDefinitionJson =
+        "{"
+            + "\"fqn\":\"fqn\","
+            + "\"type\":\"ATTRIBUTE\","
+            + "\"display_name\":\"Some Name\","
+            + "\"key\":\"key\","
+            + "\"id\":\"EVENT.key\","
+            + "\"value_kind\":\"TYPE_STRING\","
+            + "\"scope_string\":\"EVENT\","
+            + "\"definition\":{}"
+            + "}";
+
+    assertFalse(AttributeMetadataModel.fromJson(defaultDefinitionJson).toDTO().hasDefinition());
   }
 }

--- a/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
+++ b/attribute-service/src/integrationTest/java/org/hypertrace/core/attribute/service/AttributeServiceTest.java
@@ -330,6 +330,7 @@ public class AttributeServiceTest {
             .setCustom(true)
             .build();
 
+    // No custom def on attribute 2
     AttributeMetadata expectedAttributeMetadata2 =
         AttributeMetadata.newBuilder()
             .setFqn("name-2")
@@ -346,7 +347,6 @@ public class AttributeServiceTest {
             .addSources(AttributeSource.EDS)
             .setId("EVENT.key-2")
             .setGroupable(true)
-            .setDefinition(AttributeDefinition.newBuilder().setSourcePath("sourcepath-2"))
             .setScopeString(AttributeScope.EVENT.name())
             .build();
 


### PR DESCRIPTION
## Description
Long standing bug where an empty attribute definition (the default) is assigned rather than leaving the field unset. This breaks presence detection downstream (i.e. `attribute.hasAttributeDefinition()`)

### Testing
Added unit and integration test.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


