### PR TITLE
chore: update the helm chart version of config bootstraper

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -24,4 +24,4 @@ version: 0.1.0
 dependencies:
   - name: config-bootstrapper
     repository: "https://storage.googleapis.com/hypertrace-helm-charts"
-    version: 0.2.41
+    version: 0.2.42


### PR DESCRIPTION
Updating sub-chart version to latest: https://github.com/hypertrace/config-bootstrapper/releases/tag/0.2.42